### PR TITLE
Add Streamable HTTP Transport

### DIFF
--- a/multi_ssh_mcp.py
+++ b/multi_ssh_mcp.py
@@ -426,6 +426,7 @@ def main():
     # Create FastMCP server
     mcp = FastMCP("Multi-SSH Server")
     
+
     @mcp.tool()
     def list_servers() -> str:
         """List all configured SSH servers with their details"""
@@ -752,19 +753,30 @@ def main():
             return f"{command_type} failed: {result['error']}"
     
     # Run the FastMCP server with transport selection
-    transport = os.environ.get("MCP_TRANSPORT", "stdio")
+    transport = os.environ.get("MCP_TRANSPORT", "stdio").lower()
     
     if transport == "sse":
-        # Server-Sent Events mode for HTTP streaming
+        # Server-Sent Events mode for HTTP streaming (not recommended)
         import uvicorn
-        from fastmcp.sse import create_sse_transport
+        sse_transport = mcp.sse_app()
         
         port = int(os.environ.get("MCP_PORT", "8080"))
         host = os.environ.get("MCP_HOST", "0.0.0.0")
         
         logger.info(f"Starting SSE transport on {host}:{port}")
-        sse_transport = create_sse_transport(mcp, host=host, port=port)
         uvicorn.run(sse_transport, host=host, port=port, log_level="info")
+
+    elif transport == "http":
+        # Streamable HTTP transport (recommended)
+        import uvicorn
+        http_transport = mcp.http_app()
+        
+        port = int(os.environ.get("MCP_PORT", "8080"))
+        host = os.environ.get("MCP_HOST", "0.0.0.0")
+        
+        logger.info(f"Starting Streamable HTTP transport on {host}:{port}")
+        uvicorn.run(http_transport, host=host, port=port, log_level="info")
+
     else:
         # Default stdio transport
         logger.info("Starting stdio transport")

--- a/multi_ssh_mcp.py
+++ b/multi_ssh_mcp.py
@@ -20,6 +20,7 @@ import logging
 
 import paramiko
 from fastmcp import FastMCP
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 import jc
 
 # Import security utilities
@@ -424,7 +425,18 @@ def main():
     logger.info(f"Loaded {len(ssh_manager.servers_config)} server(s): {', '.join(ssh_manager.servers_config.keys())}")
     
     # Create FastMCP server
-    mcp = FastMCP("Multi-SSH Server")
+    bearer_token = os.environ.get("MCP_TOKEN", "stdio")
+    verifier = StaticTokenVerifier(
+        tokens={
+            bearer_token: {
+                "client_id": "helios@juniper.net",
+                "scopes": ["read:data", "write:data", "admin:users"]
+            }
+        },
+        required_scopes=["read:data"]
+    )
+    
+    mcp = FastMCP("Multi-SSH Server", auth=verifier)
     
 
     @mcp.tool()

--- a/multi_ssh_mcp.py
+++ b/multi_ssh_mcp.py
@@ -425,19 +425,22 @@ def main():
     logger.info(f"Loaded {len(ssh_manager.servers_config)} server(s): {', '.join(ssh_manager.servers_config.keys())}")
     
     # Create FastMCP server
-    bearer_token = os.environ.get("MCP_TOKEN", "stdio")
-    verifier = StaticTokenVerifier(
-        tokens={
-            bearer_token: {
-                "client_id": "helios@juniper.net",
-                "scopes": ["read:data", "write:data", "admin:users"]
-            }
-        },
-        required_scopes=["read:data"]
-    )
+    bearer_token = os.environ.get("MCP_TOKEN")
+
+    if bearer_token:
+        verifier = StaticTokenVerifier(
+            tokens={
+                bearer_token: {
+                    "client_id": "superuser",
+                    "scopes": ["read:data", "write:data", "admin:users"]
+                }
+            },
+            required_scopes=["read:data"]
+         )
     
-    mcp = FastMCP("Multi-SSH Server", auth=verifier)
-    
+        mcp = FastMCP("Multi-SSH Server", auth=verifier)
+    else:
+        mcp = FastMCP("Multi-SSH Server")
 
     @mcp.tool()
     def list_servers() -> str:


### PR DESCRIPTION
Quick and dirty update to add HTTP Streamable output that works with the latest versions of FastMCP. There is very basic shared token authentication, so this is just a start and should be used for development/testing. This should also fix SSE transport, but this has not been tested.